### PR TITLE
Show student's name on the mobile assist page

### DIFF
--- a/oh_queue/static/js/client/assist.js
+++ b/oh_queue/static/js/client/assist.js
@@ -15,11 +15,11 @@ $(document).ready(function(){
   var formatMessage = function(message, resolveButton) {
     rendered =
       '<div class="row queue-entry" id="queue-entry-' + message.id + '"> \
-            <div class="three columns no-hide">' + message.name + '</div> \
+            <div class="two columns no-hide">' + message.name + '</div> \
             <div class="three columns">' + message.add_date+ '</div> \
             <div class="two columns">' + message.location+ '</div> \
             <div class="two columns">' + message.assignment_type + '</div> \
-            <div class="two columns">' + message.assignment + '</div> \
+            <div class="three columns">' + message.assignment + '</div> \
             <div class="two columns">' + message.question + '</div> \
       '
     resolve = 

--- a/oh_queue/templates/assist.html
+++ b/oh_queue/templates/assist.html
@@ -20,7 +20,7 @@
 			<div class="two columns">Location</div>
 			<div class="two columns">Type</div>
 			<div class="three columns">Assignment</div>
-			<div class="three columns">Question</div>
+			<div class="two columns">Question</div>
 		</div>
 	</section>
 	
@@ -32,7 +32,7 @@
 			<div class="two columns">{{ entry.location }}</div>
 			<div class="two columns">{{ entry.assignment_type }}</div>
 			<div class="three columns">{{ entry.assignment }}</div>
-			<div class="three columns">{{ entry.question }}</div>
+			<div class="two columns">{{ entry.question }}</div>
 			<div class="two columns"><button data-url="{{ url_for('resolve_entry')}}" data-id='{{ entry.id }}' class="resolve">Resolve</button></div>
 		</div>
 		{% endfor %}


### PR DESCRIPTION
Basically removes the assignment number in exchange for showing the name when looking at the assist page from a phone in portrait mode (or just a really small phone in landscape). Name seems like the single most valuable piece of info on the assist page, and in the current version, it's hidden. 
