### PR TITLE
Toggle the tab title when a student adds themselves to the queue

### DIFF
--- a/oh_queue/static/js/client/assist.js
+++ b/oh_queue/static/js/client/assist.js
@@ -46,6 +46,7 @@ $(document).ready(function(){
 
   var resetTitle = function() {
       clearTimeout(titleToggleTimer);
+      titleToggleTimer = null;
       document.title = startTitle;
   }
 


### PR DESCRIPTION
When a new student adds themselves to the queue, makes the title toggle between "New student on queue" and the default title every second, similar to how Facebook messenger or Google hangouts act when you get a new message.
