### PR TITLE
Default to using websockets

### DIFF
--- a/oh_queue/__init__.py
+++ b/oh_queue/__init__.py
@@ -1,6 +1,3 @@
-from gevent import monkey
-monkey.patch_all()
-
 import logging
 logging.basicConfig(level=logging.INFO)
 

--- a/oh_queue/static/js/common.js
+++ b/oh_queue/static/js/common.js
@@ -10,6 +10,12 @@ function notifyUser(text, options) {
   }
 }
 
+function connectSocket() {
+  return io.connect('http://' + document.domain + ':' + location.port, {
+    transports: ['websocket', 'polling'],
+  });
+}
+
 $(document).ready(function(){
   // Bind event listeners
   $('body').on('click', '[data-url]', function(event) {

--- a/oh_queue/static/js/index.js
+++ b/oh_queue/static/js/index.js
@@ -1,5 +1,5 @@
 $(document).ready(function(){
-  var socket = io.connect('http://' + document.domain + ':' + location.port);
+  var socket = connectSocket();
 
   if (is_staff || has_open_ticket) {
     requestNotificationPermission();

--- a/oh_queue/static/js/ticket.js
+++ b/oh_queue/static/js/ticket.js
@@ -1,5 +1,5 @@
 $(document).ready(function(){
-  var socket = io.connect('http://' + document.domain + ':' + location.port);
+  var socket = connectSocket();
 
   requestNotificationPermission();
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,6 @@ Flask-OAuthlib==0.9.3
 Flask-Script==2.0.5
 Flask-SocketIO==2.6.2
 Flask-SQLAlchemy==2.1
-gevent==1.1.2
-greenlet==0.4.10
 itsdangerous==0.24
 Jinja2==2.8
 MarkupSafe==0.23
@@ -22,3 +20,4 @@ Werkzeug==0.11.10
 
 gunicorn==19.6.0
 pymysql==0.7.6
+eventlet==0.19.0


### PR DESCRIPTION
- Use eventlet instead of gevent, since gevent does not have
  websocket support out of the box.
- Change socket.io client config to default to websockets.

Resolves #43
