### PR TITLE
Refresh existing tickets on reconnect

### DIFF
--- a/oh_queue/static/js/components/app.js
+++ b/oh_queue/static/js/components/app.js
@@ -22,7 +22,10 @@ class App extends React.Component {
 
     let socket = connectSocket();
     this.socket = socket;
-    socket.on('connect', () => app.setOffline(false));
+    socket.on('connect', () => {
+      app.setOffline(false);
+      app.refreshTickets();
+    });
     socket.on('disconnect', () => app.setOffline(true));
     socket.on('state', (data) => app.updateState(data));
     socket.on('event', (data) => app.updateTicket(data.ticket));
@@ -44,6 +47,16 @@ class App extends React.Component {
       setTicket(this.state, ticket);
     }
     this.refresh();
+  }
+
+  refreshTickets() {
+    let ticketIDs = Array.from(this.state.tickets.keys());
+    this.socket.emit('refresh', ticketIDs, (data) => {
+      for (var ticket of data.tickets) {
+        setTicket(this.state, ticket);
+      }
+      this.refresh();
+    });
   }
 
   updateTicket(ticket) {

--- a/oh_queue/views.py
+++ b/oh_queue/views.py
@@ -94,6 +94,13 @@ def connect():
             user_json(current_user) if current_user.is_authenticated else None,
     })
 
+@socketio.on('refresh')
+def refresh(ticket_ids):
+    tickets = Ticket.query.filter(Ticket.id.in_(ticket_ids)).all()
+    return {
+        'tickets': [ticket_json(ticket) for ticket in tickets],
+    }
+
 @socketio.on('create')
 @logged_in
 def create(form):


### PR DESCRIPTION
Resolves #82

Testing:
- Bring the server up on port 5000.
- Load the page.
- Kill the server.
- Bring the server up on port 5001.
- In a new tab, resolve a ticket.
- Kill the server.
- Bring the server up on port 5000 again.
- Go back to the new tab. The resolved ticket should be resolved on reconnect.

Will put up on staging and test on my phone
