### PR TITLE
Do not send other student info over the wire

### DIFF
--- a/oh_queue/views.py
+++ b/oh_queue/views.py
@@ -21,8 +21,8 @@ def user_json(user):
 
 def student_json(user):
     """ Only send student information to staff. """
-    can_see_details = (current_user.is_authenticated and
-                       (current_user.is_staff or user.id == current_user.id))
+    can_see_details = (current_user.is_authenticated
+                        and (current_user.is_staff or user.id == current_user.id))
     if not can_see_details:
         return {}
     return user_json(user)


### PR DESCRIPTION
Right now we send student info (like name & email) over the wire even if some is unauthenticated or is just a student. 

This prevents that by sending fake info (which is fine because they can't see it anyway) 

Feel free to make changes. 