### PR TITLE
Moves all course-specific config to environment variables

### DIFF
--- a/oh_queue/assets.py
+++ b/oh_queue/assets.py
@@ -27,6 +27,8 @@ def glob_assets(pattern):
     finally:
         os.chdir(cwd)
 
+assets_env.config['BABEL_EXTRA_ARGS'] = ["--plugins", "preval"]
+
 assets_env.register('common.js',
     *glob_assets('js/components/*.js'),
     'js/state.js',

--- a/oh_queue/static/js/state.js
+++ b/oh_queue/static/js/state.js
@@ -222,48 +222,18 @@ function clearMessage(state: State, id: number): void {
   }
 }
 
-/* Constants */
-const ASSIGNMENTS = [
-  'Project 1 (Hog)',
-  'Project 2 (Maps)',
-  'Project 3 (Ants)',
-  'Project 4 (Scheme)',
-  'Homework 0',
-  'Homework 1',
-  'Homework 2',
-  'Homework 3',
-  'Homework 4',
-  'Homework 5',
-  'Homework 6',
-  'Homework 7',
-  'Homework 8',
-  'Homework 9',
-  'Homework 10',
-  'Homework 11',
-  'Homework 12',
-  'Lab 0',
-  'Lab 1',
-  'Lab 2',
-  'Lab 3',
-  'Lab 4',
-  'Lab 5',
-  'Lab 6',
-  'Lab 7',
-  'Lab 8',
-  'Lab 9',
-  'Lab 10',
-  'Lab 11',
-  'Lab 12',
-  'Lab 13',
-  'Lab 14',
-  'Midterm 1',
-  'Midterm 2',
-  'Final',
-  'Other',
-];
+const ASSIGNMENTS = preval`
+  if (process.env.ASSIGNMENTS) {
+    module.exports = process.env.ASSIGNMENTS.split(',');
+  } else {
+    module.exports = ['Any'];
+  }
+`;
 
-const LOCATIONS = [
-  '109 Morgan',
-  '247 Cory',
-  '241 Cory'
-];
+const LOCATIONS = preval`
+  if (process.env.LOCATIONS) {
+    module.exports = process.env.LOCATIONS.split(',');
+  } else {
+    module.exports = ['Any'];
+  }
+`;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "babel-cli": "^6.14.0",
     "babel-preset-es2015": "^6.14.0",
-    "babel-preset-react": "^6.11.1"
+    "babel-preset-react": "^6.11.1",
+    "babel-plugin-preval": "^1.5.0"
   },
   "devDependencies": {
     "flow-bin": "^0.32.0"


### PR DESCRIPTION
ASSIGNMENTS and LOCATIONS should both be environment variables that contain comma separated lists of assignments and locations respectively.

These are compiled as constants within state.js by using the babel preval plugin to split the environment variables at compile time.

COURSE_NAME and OFFERING exited previously.

This should allow all normal course OH queues to be deployed off of the same branch. We'll still need a separate branch for the online queue for the time being.

