### PR TITLE
Improve Wait Time Estimation

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -29,7 +29,7 @@ def not_in_production(f):
 @not_in_production
 def seed():
     print('Seeding...')
-    for i in range(20):
+    for i in range(50):
         real_name = names.get_full_name()
         first_name, last_name = real_name.lower().split(' ')
         email = '{0}{1}@{2}'.format(


### PR DESCRIPTION
- Correct off by one error 
- More rigorous interval bound + documentation
- "Unknown" -> ?? looks neater (imo)

Estimates are now as follows (assistants start off unassigned):
20 Queued, 10 Assist. => 10-12 min
20 Queued, 0 Assist. => ?? min
20 Queued, 1 Assist. => 180-220 min
20 Queued, 20 Assist. => 0-2 min