### PR TITLE
Call virtualenv more robustly

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This app uses [Ok](https://okpy.org) to manage access. Even if you aren't using 
 
 1. Create an activate a virtualenv:
 
-    virtualenv -p python3 env
+    python3 -m virtualenv env
 
     source env/bin/activate
 


### PR DESCRIPTION
Runs virtualenv via Python and also tell it to use the same executable as the one it is run with.

It's less confusing and it avoids problems where it picks up a different version of Python than the user actually wanted to run it with. (I had this problem.)