### PR TITLE
Assign notification tags

### DIFF
--- a/oh_queue/static/js/common.js
+++ b/oh_queue/static/js/common.js
@@ -8,20 +8,28 @@ function requestNotificationPermission() {
   }
 }
 
-function notifyUser(title, body) {
+function notifyUser(title, body, tag) {
   try {
     Push.create(title, {
-      'body': body,
-      'icon': window.location.origin + "/static/img/logo-tiny.png",
-       onClick: function () {
+      body: body,
+      icon: window.location.origin + "/static/img/logo-tiny.png",
+      onClick: function () {
           window.focus();
           this.close();
-      }
+      },
+      tag: tag
     });
   } catch (e) {
     // Ignore Push.js errors about unsupported devices
   }
+}
 
+function cancelNotification(tag) {
+  try {
+    Push.close(tag);
+  } catch (e) {
+    // Ignore Push.js errors about unsupported devices
+  }
 }
 
 function connectSocket() {

--- a/oh_queue/static/js/components/app.js
+++ b/oh_queue/static/js/components/app.js
@@ -70,12 +70,29 @@ class App extends React.Component {
   }
 
   updateTicket(data) {
-    if (this.shouldNotify(data.ticket, data.type)) {
-        notifyUser("New Request for " + data.ticket.assignment,
-                   data.ticket.location);
-    }
     setTicket(this.state, data.ticket);
     this.refresh();
+
+    var ticket = data.ticket;
+    switch(data.type) {
+      case 'assign':
+      case 'delete':
+      case 'resolve':
+        if(isStaff(this.state)) {
+          cancelNotification(ticket.id + ".create");
+        }
+        break;
+      case 'create':
+      case 'describe':
+      case 'unassign':
+      case 'update_location':
+        if(isStaff(this.state) && ticket.status === 'pending') {
+          notifyUser('New Request for ' + ticket.assignment,
+                     ticket.location,
+                     ticket.id + '.create');
+        }
+        break;
+    }
   }
 
   loadTicket(id) {

--- a/oh_queue/static/js/state.js
+++ b/oh_queue/static/js/state.js
@@ -130,9 +130,14 @@ function getTicket(state: State, id: number): ?Ticket {
 function setTicket(state: State, ticket: Ticket): void {
   if (ticketIsMine(state, ticket)) {
     let oldTicket = getMyTicket(state);
-    if (oldTicket && oldTicket.status === "pending" && ticket.status === "assigned") {
-      notifyUser("Your name is being called",
-                 ticket.helper.name + " is looking for you in "+ ticket.location);
+    if (oldTicket) {
+      if(oldTicket.status === 'pending' && ticket.status === 'assigned') {
+        notifyUser('Your name is being called',
+                   ticket.helper.name + ' is looking for you in '+ ticket.location,
+                   ticket.id + '.assign');
+      } else if (oldTicket.status === 'assigned' && ticket.status !== 'assigned') {
+        cancelNotification(ticket.id + '.assign');
+      }
     }
   }
   state.tickets.set(ticket.id, ticket);


### PR DESCRIPTION
The Notifications API supports assigning tags to notifications. This enables us to do stuff like:

- Prevent duplicate notifications (e.g. multiple tabs, fixes #58). A new notification with the same tag as an existing one will replace the old one, instead of making a second one
- Programmatically dismiss notifications
  - This commit adds basic support for auto-dismissing the "create" notification for AIs when an AI begins helping that ticket, and auto-dismissing the "assigned" notification for the ticket creator when the ticket exits "assigned" status

Notification tags should be standardized in the format `<ticket_id>.<event_type>`. There are currently two event types we send notifications for:

- `"create"`: When a ticket is created, AIs are notified with `<ticket_id>.create`
- `"assign"`: When an AI assigns a ticket, the ticket creator is notified with `<ticket_id>.assign`