### PR TITLE
Add timer showing time since a staff member started helping a ticket

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,37 +11,42 @@ This app uses [Ok](https://okpy.org) to manage access. Even if you aren't using 
 
 ## Installation
 
-0. Clone this repo:
+1. Clone this repo:
 
+    ```
+    git clone https://github.com/Cal-CS-61A-Staff/oh-queue.git
+    ```
+Then cd into it:
 ```
-git clone https://github.com/Cal-CS-61A-Staff/oh-queue.git
+cd oh-queue
 ```
 
-1. Create an activate a virtualenv:
+2. Create and activate a virtualenv:
+    ```
+        python3 -m virtualenv env  (If this does not work, try: `virtualenv -p python3 env`)
+        source env/bin/activate
+    ```
 
-    python3 -m virtualenv env  (If this does not work, try: `virtualenv -p python3 env`)
-
-    source env/bin/activate
-
-2. Use pip to install all the dependencies:
-
+3. Use pip to install all the dependencies:
+    ```
     pip install -r requirements.txt
-
     npm install
+    ```
 
-3. Reset the database to create tables.
-
+4. Reset the database to create tables.
+    ```
     ./manage.py resetdb
-    
+    ```
     If you get the error "TypeError: OAuthRemoteApp requires consumer key and secret", you need to set your OK_KEY and OK_SECRET environment variables.
 
-4. Run the server:
-
+5. Run the server:
+    ```
     ./manage.py server
+    ```
 
-5. Point your browser to http://localhost:5000.  (This might take a while.)
+6. Point your browser to http://localhost:5000.  (This might take a while the first time.)
 
-6. You can log in as any email while testing by going to http://localhost:5000/testing-login/.
+7. You can log in as any email while testing by going to http://localhost:5000/testing-login/.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ This app uses [Ok](https://okpy.org) to manage access. Even if you aren't using 
     ```
     git clone https://github.com/Cal-CS-61A-Staff/oh-queue.git
     ```
-Then cd into it:
-```
-cd oh-queue
-```
+    Then cd into it:
+    ```
+    cd oh-queue
+    ```
 
 2. Create and activate a virtualenv:
     ```
-        python3 -m virtualenv env  (If this does not work, try: `virtualenv -p python3 env`)
-        source env/bin/activate
+    python3 -m virtualenv env  (If this does not work, try: `virtualenv -p python3 env`)
+    source env/bin/activate
     ```
 
 3. Use pip to install all the dependencies:

--- a/oh_queue/models.py
+++ b/oh_queue/models.py
@@ -56,7 +56,7 @@ class Ticket(db.Model):
 
     user_id = db.Column(db.ForeignKey('user.id'), nullable=False, index=True)
     assignment = db.Column(db.String(255), nullable=False)
-    question = db.Column(db.String(255), nullable=False)
+    question = db.Column(db.String(255), nullable=True)
     location = db.Column(db.String(255), nullable=False)
 
     description = db.Column(db.Text)

--- a/oh_queue/static/css/style.css
+++ b/oh_queue/static/css/style.css
@@ -204,6 +204,15 @@ hr {
   margin-top: 4px;
 }
 
+.ticket-created-md {
+  padding-left: 12px;
+}
+
+.ticket-desc-xs {
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
 .ticket-status-md {
   padding-right: 12px;
 }

--- a/oh_queue/static/js/components/ticket.js
+++ b/oh_queue/static/js/components/ticket.js
@@ -4,7 +4,7 @@ let Ticket = ({state, ticket}) => {
     status = ticketDisplayTime(ticket) + ' in ' + ticket.location;
   } else {
     if (isStaff(state)) {
-      status = (isTicketHelper(state, ticket) ? 'you' : ticket.helper.name) + ' (' + ticketTimeAgo(ticket)+ ')';
+      status = (isTicketHelper(state, ticket) ? 'You' : ticket.helper.name) + ' (Started helping ' + ticketTimeSinceAssigned(ticket)+ ')';
     } else {
       status = ticketStatus(state, ticket);
     }
@@ -15,6 +15,7 @@ let Ticket = ({state, ticket}) => {
     description = ticket.description;
   }
 
+
   return (
     <TicketLink state={state} ticket={ticket}>
       <div className="pull-left ticket-index">{ticketPosition(state, ticket)}</div>
@@ -23,8 +24,10 @@ let Ticket = ({state, ticket}) => {
         <br className="visible-xs" />
         <small className="visible-xs ticket-status-xs">{status}</small>
         <small className="visible-xs ticket-desc-xs">{description}</small>
+        <small className="visible-xs ticket-created-xs">Ticket created: {ticketTimeAgo(ticket)}</small> 
       </h4>
       <h4 className="pull-left hidden-xs ticket-desc-md "><small>{description}</small></h4>
+      <h4 className="pull-left hidden-xs ticket-created-md "><small>Ticket created: {ticketTimeAgo(ticket)}</small></h4>
       <h4 className="pull-right hidden-xs ticket-status-md">
         <small>{status} {moment.duration(moment.utc().diff(moment.utc(ticket.created))).asDays() > 1 &&
         <span className="badge"> Old Ticket </span>}

--- a/oh_queue/static/js/state.js
+++ b/oh_queue/static/js/state.js
@@ -18,6 +18,7 @@ type Ticket = {
   status: 'pending' | 'assigned' | 'resolved' | 'deleted',
   user: User,
   created: string,  // ISO 8601 datetime string
+  updated: string,
   location: string,
   assignment: string,
   question: string,
@@ -84,6 +85,10 @@ function ticketDisplayTime(ticket: Ticket): string {
 
 function ticketTimeAgo(ticket: Ticket): string {
   return moment.utc(ticket.created).fromNow()
+}
+
+function ticketTimeSinceAssigned(ticket: Ticket): string {
+  return moment.utc(ticket.updated).fromNow()
 }
 
 function isPending(ticket: Ticket): boolean {

--- a/oh_queue/views.py
+++ b/oh_queue/views.py
@@ -33,6 +33,7 @@ def ticket_json(ticket):
         'status': ticket.status.name,
         'user': student_json(ticket.user),
         'created': ticket.created.isoformat(),
+        'updated': ticket.updated.isoformat(),
         'location': ticket.location,
         'assignment': ticket.assignment,
         'description': ticket.description,
@@ -223,6 +224,7 @@ def assign(ticket_ids):
     tickets = get_tickets(ticket_ids)
     for ticket in tickets:
         ticket.status = TicketStatus.assigned
+
         ticket.helper_id = current_user.id
         emit_event(ticket, TicketEventType.assign)
     db.session.commit()

--- a/oh_queue/views.py
+++ b/oh_queue/views.py
@@ -28,18 +28,31 @@ def student_json(user):
     return user_json(user)
 
 def ticket_json(ticket):
-    return {
-        'id': ticket.id,
-        'status': ticket.status.name,
-        'user': student_json(ticket.user),
-        'created': ticket.created.isoformat(),
-        'updated': ticket.updated.isoformat(),
-        'location': ticket.location,
-        'assignment': ticket.assignment,
-        'description': ticket.description,
-        'question': ticket.question,
-        'helper': ticket.helper and user_json(ticket.helper),
-    }
+    if ticket.updated is None:
+        return {
+            'id': ticket.id,
+            'status': ticket.status.name,
+            'user': student_json(ticket.user),
+            'created': ticket.created.isoformat(),
+            'location': ticket.location,
+            'assignment': ticket.assignment,
+            'description': ticket.description,
+            'question': ticket.question,
+            'helper': ticket.helper and user_json(ticket.helper),
+        }
+    else: 
+        return {
+            'id': ticket.id,
+            'status': ticket.status.name,
+            'user': student_json(ticket.user),
+            'created': ticket.created.isoformat(),
+            'updated': ticket.updated.isoformat(),
+            'location': ticket.location,
+            'assignment': ticket.assignment,
+            'description': ticket.description,
+            'question': ticket.question,
+            'helper': ticket.helper and user_json(ticket.helper),
+        }
 
 def emit_event(ticket, event_type):
     ticket_event = TicketEvent(


### PR DESCRIPTION
Resolves #76. This pull requests adds a feature for staff so staff can see how long a staff member has been helping a ticket for. 

Screenshot from staff perspective:
![screen shot 2019-02-22 at 3 17 38 pm](https://user-images.githubusercontent.com/35756462/53277140-4e2d0880-36b7-11e9-89fc-6599063844d0.png)

The following screenshot was taken after a ticket was requeued. This shows that the "timer since ticket was assigned" does not show when a ticket is in the queue, even if it was previously assigned.
![screen shot 2019-02-22 at 3 34 00 pm](https://user-images.githubusercontent.com/35756462/53277145-5127f900-36b7-11e9-976b-0029b364ad50.png)

View from a student's perspective - the "time since ticket was assigned" timer does not display for the student. 
![screen shot 2019-02-22 at 3 36 01 pm](https://user-images.githubusercontent.com/35756462/53277207-9f3cfc80-36b7-11e9-9e4c-0f3d63bd7914.png)

There is only one trivial issue, in that if a ticket has been assigned and the student changes the description, this timer will update. However, it's unlikely that a student would change the description while they are already being helped.