### PR TITLE
Add server error view

### DIFF
--- a/oh_queue/static/css/style.css
+++ b/oh_queue/static/css/style.css
@@ -92,6 +92,10 @@ a:hover {
   background-color: rgba(0, 0, 0, 0.05);
 }
 
+.error-view {
+  margin-top: 20px;
+}
+
 .ticket {
   margin-top: 20px;
 }

--- a/oh_queue/static/js/components/app.js
+++ b/oh_queue/static/js/components/app.js
@@ -134,6 +134,7 @@ class App extends React.Component {
         createElement={createElement}>
         <ReactRouter.Route path="/" component={Base}>
           <ReactRouter.IndexRoute component={Queue}/>
+          <ReactRouter.Route path="/error" component={ErrorView}/>
           <ReactRouter.Route path="/:id/" component={TicketView}/>
         </ReactRouter.Route>
         <ReactRouter.Route path="/presence" component={PresenceIndicator}/>

--- a/oh_queue/static/js/components/error_view.js
+++ b/oh_queue/static/js/components/error_view.js
@@ -1,0 +1,25 @@
+class ErrorView extends React.Component {
+  componentWillMount() {
+    let query = Qs.parse(this.props.location.search.substring(1));
+    let state = this.props.state;
+
+    state.message = query.message || 'Unknown error';
+  }
+
+  render() {
+    let state = this.props.state;
+
+    return (
+      <div className="container error-view">
+        <div className="row">
+          <div className="col-xs-12">
+            <div className="alert alert-danger">
+              <p>{ state.message }</p>
+            </div>
+            <ReactRouter.Link className="btn btn-primary" to="/">Home</ReactRouter.Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/oh_queue/templates/default.html
+++ b/oh_queue/templates/default.html
@@ -29,6 +29,7 @@
 
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/qs/6.6.0/qs.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.7.3/socket.io.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.11.0/js/bootstrap-select.min.js"></script>

--- a/oh_queue/views.py
+++ b/oh_queue/views.py
@@ -64,6 +64,10 @@ user_presence = collections.defaultdict(set) # An in memory map of presence.
 def index(*args, **kwargs):
     return render_template('index.html')
 
+@app.route('/error')
+def error(*args, **kwargs):
+    return render_template('index.html')
+
 def socket_error(message, category='danger', ticket_id=None):
     return {
         'messages': [
@@ -178,7 +182,7 @@ def update_location(location):
     ticket = Ticket.query.filter(Ticket.id == ticket_id).first()
     if not (current_user.is_staff or ticket.user.id == current_user.id):
             return socket_unauthorized()
-            
+
     ticket.location = new_location
     emit_event(ticket, TicketEventType.update_location)
 


### PR DESCRIPTION
Added a basic React route for displaying server-side errors.

Failed OAuth2 authorizations will now display an error using this view, instead of a 500 Internal Server Error. Fixes #62 