### PR TITLE
Fix HTML5 form validation

### DIFF
--- a/oh_queue/static/js/components/request_form.js
+++ b/oh_queue/static/js/components/request_form.js
@@ -1,8 +1,13 @@
 let RequestForm = () => {
   let submit = (e) => {
     e.preventDefault();
+    let form = $('#request-form');
+    let formDOM = form[0];
+    if(formDOM.reportValidity && !formDOM.reportValidity()) {
+      return;
+    }
     let formData = {};
-    $('#request-form').serializeArray().forEach((input) => {
+    form.serializeArray().forEach((input) => {
       formData[input.name] = input.value;
     });
     app.makeRequest('create', formData, true);


### PR DESCRIPTION
We rely on server-side ticket validation currently. Triggering HTML5 form validation presents users with a clearer description of what field(s) are filled incorrectly and why. If the browser does not support `reportValidity()` (most modern ones do), fallback to server validation.

This technically fixes #64; Safari has supported this since ~2017 Q1, but our use of `e.preventDefault()` blocks natural browser validation (in other browsers too), so we need to manually trigger the validity report from our code.

Validation tested to work on modern Safari, Firefox, Chrome. Fallback tested to work on older Firefox.