### PR TITLE
Add button to resolve and fetch next ticket locally

### DIFF
--- a/oh_queue/static/js/components/group_actions.js
+++ b/oh_queue/static/js/components/group_actions.js
@@ -21,7 +21,7 @@ let GroupActions = ({state, status, tickets}) => {
         className="btn btn-warning pull-right">
         Requeue all
       </button>,
-      <button onClick={() => app.makeRequest('resolve', ticket_ids)}
+      <button onClick={() => app.makeRequest('resolve', {'ticket_ids': ticket_ids})}
       className="btn btn-primary pull-right">
       Resolve all
       </button>,

--- a/oh_queue/static/js/components/ticket_buttons.js
+++ b/oh_queue/static/js/components/ticket_buttons.js
@@ -4,6 +4,7 @@ class TicketButtons extends React.Component {
     this.assign = this.assign.bind(this);
     this.delete = this.delete.bind(this);
     this.resolveAndNext = this.resolveAndNext.bind(this);
+    this.resolveAndLocalNext = this.resolveAndLocalNext.bind(this);
     this.resolve = this.resolve.bind(this);
     this.unassign = this.unassign.bind(this);
     this.reassign = this.reassign.bind(this);
@@ -20,11 +21,15 @@ class TicketButtons extends React.Component {
   }
 
   resolveAndNext() {
-    app.makeRequest('resolve', [this.props.ticket.id], true)
+    app.makeRequest('resolve', {'ticket_ids': [this.props.ticket.id]}, true)
+  }
+
+  resolveAndLocalNext() {
+    app.makeRequest('resolve', {'ticket_ids': [this.props.ticket.id], 'local': true}, true)
   }
 
   resolve() {
-    app.makeRequest('resolve', [this.props.ticket.id]);
+    app.makeRequest('resolve', {'ticket_ids': [this.props.ticket.id]});
   }
 
   unassign() {
@@ -75,6 +80,7 @@ class TicketButtons extends React.Component {
       bottomButtons.push(makeButton('Resolve', 'default', this.resolve));
       if (staff) {
         if (ticket.helper.id === state.currentUser.id) {
+          topButtons.push(makeButton('Resolve and Next in Room', 'primary', this.resolveAndLocalNext)); 
           topButtons.push(makeButton('Resolve and Next', 'primary', this.resolveAndNext));
           bottomButtons.push(makeButton('Requeue', 'default', this.unassign));
         } else {

--- a/oh_queue/views.py
+++ b/oh_queue/views.py
@@ -210,16 +210,21 @@ def update_location(data, ticket):
 def get_tickets(ticket_ids):
     return Ticket.query.filter(Ticket.id.in_(ticket_ids)).all()
 
-def get_next_ticket():
+def get_next_ticket(location=None):
     """Return the user's first assigned but unresolved ticket.
     If none exist, return to the first unassigned ticket.
+
+    If a location is passed in, only returns a next ticket from
+    provided location.
     """
     ticket = Ticket.query.filter(
         Ticket.helper_id == current_user.id,
         Ticket.status == TicketStatus.assigned).first()
     if not ticket:
-        ticket = Ticket.query.filter(
-            Ticket.status == TicketStatus.pending).first()
+        ticket = Ticket.query.filter(Ticket.status == TicketStatus.pending)
+        if location:
+            ticket = ticket.filter(Ticket.location == location)
+        ticket = ticket.first()
     if ticket:
         return socket_redirect(ticket_id=ticket.id)
     else:
@@ -243,15 +248,25 @@ def delete(ticket_ids):
 
 @socketio.on('resolve')
 @logged_in
-def resolve(ticket_ids):
+def resolve(data):
+    """Gets ticket_ids and an optional argument 'local'.
+    Resolves all ticket_ids. If 'local' is set, then
+    will only return a next ticket from the same location
+    where the last ticket was resolved from.
+    """
+    ticket_ids = data.get('ticket_ids')
+    local = data.get('local', False)
+    location = None
     tickets = get_tickets(ticket_ids)
     for ticket in tickets:
         if not (current_user.is_staff or ticket.user.id == current_user.id):
             return socket_unauthorized()
         ticket.status = TicketStatus.resolved
+        if local:
+            location = ticket.location
         emit_event(ticket, TicketEventType.resolve)
     db.session.commit()
-    return get_next_ticket()
+    return get_next_ticket(location)
 
 @socketio.on('assign')
 @is_staff


### PR DESCRIPTION
I.e., from the same location. 

This enhances the use of the OH Queue to effective simultaneous use in multiple locations at once. For instance, if a staff member is in Soda 271, then they naturally only want to see requests from Soda 271. The resolve and next in room button allows this. 