### PR TITLE
Remove the 'View Latest Backup' Button

### DIFF
--- a/oh_queue/static/js/components/ticket_buttons.js
+++ b/oh_queue/static/js/components/ticket_buttons.js
@@ -92,10 +92,7 @@ class TicketButtons extends React.Component {
     if (staff && (ticket.status === 'resolved' || ticket.status === 'deleted')) {
       topButtons.push(makeButton('Next Ticket', 'default', this.next));
     }
-    if (staff && ticket.status !== "pending") {
-      topButtons.push(makeLink('View Latest Backup', 'default', 'https://okpy.org/admin/course/4/'+encodeURIComponent(ticket.user.email)))
-    }
-
+    
     let hr = topButtons.length && bottomButtons.length ? <hr/> : null;
 
     if (!(topButtons.length || bottomButtons.length)) {


### PR DESCRIPTION
fixes #172 

Currently, this button serves no purpose for the AIs using it and we should not be hardcoding the class URL. Seeing as class IDs vary with the offered semester in Ok, I doubt the link is up to date either. Whether AIs should be able to view backups is a separate discussion. 