### PR TITLE
Add default value for `queue_magic_word_mode`

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -83,6 +83,11 @@ def seed_defaults():
         value='true',
         public=True
     ))
+    db.session.add(ConfigEntry(
+        key='queue_magic_word_mode',
+        value='none',
+        public=True
+    ))
     db.session.commit()
 
 @manager.command


### PR DESCRIPTION
Adds a default value for the `queue_magic_word_mode` config variable in `manage.py` so that when `initdb` or `resetdb` is called the correct value is seeded