### PR TITLE
feat: display UTC offset after timezone abbreviation

### DIFF
--- a/oh_queue/static/js/state.js
+++ b/oh_queue/static/js/state.js
@@ -405,7 +405,7 @@ function formatAppointmentDuration(appointment) {
     if (currTimeZone === referenceTimeZone) {
         return `${getAppointmentStartTime(appointment).format("h:mma")}‐${getAppointmentEndTime(appointment).format("h:mma")}`;
     } else {
-        return `${getAppointmentStartTime(appointment).format("h:mma")}‐${getAppointmentEndTime(appointment).format("h:mma z")}`;
+        return `${getAppointmentStartTime(appointment).format("h:mma")}‐${getAppointmentEndTime(appointment).format("h:mma z")} (UTC${getAppointmentEndTime(appointment).format("Z")})`;
     }
 }
 
@@ -413,6 +413,6 @@ function formatAppointmentDurationWithDate(appointment) {
     if (currTimeZone === referenceTimeZone) {
         return `${getAppointmentStartTime(appointment).format("dddd, MMMM D")} at ${getAppointmentStartTime(appointment).format("h:mma")}‐${getAppointmentEndTime(appointment).format("h:mma")}`;
     } else {
-        return `${getAppointmentStartTime(appointment).format("dddd, MMMM D")} at ${getAppointmentStartTime(appointment).format("h:mma")}‐${getAppointmentEndTime(appointment).format("h:mma z")}`;
+        return `${getAppointmentStartTime(appointment).format("dddd, MMMM D")} at ${getAppointmentStartTime(appointment).format("h:mma")}‐${getAppointmentEndTime(appointment).format("h:mma z")} (UTC${getAppointmentEndTime(appointment).format("Z")})`;
     }
 }


### PR DESCRIPTION
[Timezone abbreviations have a ridiculous number of conflicts on a global scale](https://en.wikipedia.org/wiki/List_of_time_zone_abbreviations).

Before: `10:30am-10:45am CST`

After: `10:30am-10:45am CST (UTC+08:00)`

Some thoughts:
- Displaying both abbrev. and offset does makes the string somewhat long
- Displaying only the offset can be slightly confusing, since most people are more familiar with the abbrev.
- Displaying only the abbrev. causes confusion (is CST Central Standard Time or China Standard Time?)
- Displaying "local" also causes confusion, e.g. if browser timezone differs from geographic timezone