### PR TITLE
Fix double counting appointments

### DIFF
--- a/oh_queue/static/js/components/admin_appointments_manager.js
+++ b/oh_queue/static/js/components/admin_appointments_manager.js
@@ -61,8 +61,11 @@ function AdminAppointmentsManager({ state }) {
                 <tr>
                     <td>
                         <p>
-                            How many appointments should a student have be pending simultaneously?
+                        How many appointments should a student have be pending simultaneously?
                         </p>
+                            (by 
+                            <ConfigLinkedToggle config={state.config} configKey="appointment_or_minutes" onText="minutes" offText="number"/> 
+                            )
                     </td>
                     <td className="col-md-3">
                         <ConfigLinkedNumeric


### PR DESCRIPTION
If a student was at max capacity (number of appointments per day or week), they would not be able to edit the descriptions of their appointments.